### PR TITLE
Add links to Linux.com Q&A

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ internally by our IT staff in hopes that they will come in handy for other
 organizations, and especially for open-source projects who rely on volunteer
 admin efforts to manage their infrastructure.
 
-We invite all others to participate, share and donate back their knowledge and
-expertise to help create a library of checklists and best practice documents
+[We invite all others to participate, share and donate back their knowledge and
+expertise][1] to help create a library of checklists and best practice documents
 that can be freely used and adapted by others.
 
 ## License
@@ -15,3 +15,5 @@ Documents in this repository are licensed under the Creative Commons
 Attribution-ShareAlike 4.0 International License. To view a copy of this
 license, visit http://creativecommons.org/licenses/by-sa/4.0/ or send a letter
 to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+[1]: http://www.linux.com/news/featured-blogs/167-amanda-mcpherson/850607-linux-foundation-sysadmins-open-source-their-it-policies

--- a/linux-workstation-security.md
+++ b/linux-workstation-security.md
@@ -28,6 +28,11 @@ is a crazy person. These guidelines are merely a basic set of core safety
 rules that is neither exhaustive, nor a replacement for experience, vigilance,
 and common sense.
 
+We're sharing this document as a way to
+[bring the benefits of open-source collaboration to IT policy documentation][18]. If
+you find it useful, we hope you'll contribute to its development by making a fork for
+your own organization and sharing your improvements. 
+
 ### Structure
 
 Each section is split into two areas:
@@ -812,3 +817,4 @@ This work is licensed under a
 [15]: https://github.com/lfit/ssh-gpg-smartcard-config
 [16]: http://www.pavelkogan.com/2014/05/23/luks-full-disk-encryption/
 [17]: https://en.wikipedia.org/wiki/Cold_boot_attack
+[18]: http://www.linux.com/news/featured-blogs/167-amanda-mcpherson/850607-linux-foundation-sysadmins-open-source-their-it-policies


### PR DESCRIPTION
This commit adds links to the Linux.com Q&A on the motivation behind releasing these documents.