### PR TITLE
Corrected the URL for Fedora Security Guide

### DIFF
--- a/linux-workstation-security.md
+++ b/linux-workstation-security.md
@@ -835,7 +835,7 @@ The world of IT security is a rabbit hole with no bottom. If you would like to
 go deeper, or find out more about security features on your particular
 distribution, please check out the following links:
 
-- [Fedora Security Guide](https://docs.fedoraproject.org/en-US/Fedora/19/html/Security_Guide/index.html)
+- [Fedora Security Guide](https://docs-old.fedoraproject.org/en-US/Fedora/19/html/Security_Guide/index.html)
 - [CESG Ubuntu Security Guide](https://www.gov.uk/government/publications/end-user-devices-security-guidance-ubuntu-1404-lts)
 - [Debian Security Manual](https://www.debian.org/doc/manuals/securing-debian-howto/index.en.html)
 - [Arch Linux Security Wiki](https://wiki.archlinux.org/index.php/Security)


### PR DESCRIPTION
Hi everyone,

I have corrected the URL for the Fedora Security Guide. Actually, it has changed from https://docs.fedoraproject.org/en-US/Fedora/19/html/Security_Guide/index.html to https://docs-old.fedoraproject.org/en-US/Fedora/19/html/Security_Guide/index.html ;-)

Best regards,