### PR TITLE
Fix Broken links to Announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Attribution-ShareAlike 4.0 International License. To view a copy of this
 license, visit http://creativecommons.org/licenses/by-sa/4.0/ or send a letter
 to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
 
-[1]: http://www.linux.com/news/featured-blogs/167-amanda-mcpherson/850607-linux-foundation-sysadmins-open-source-their-it-policies
+[1]: https://www.linuxfoundation.org/blog/2015/09/linux-foundation-sysadmins-open-source-their-it-policies/

--- a/linux-workstation-security.md
+++ b/linux-workstation-security.md
@@ -791,7 +791,7 @@ This work is licensed under a
 [15]: https://github.com/lfit/ssh-gpg-smartcard-config
 [16]: http://www.pavelkogan.com/2014/05/23/luks-full-disk-encryption/
 [17]: https://en.wikipedia.org/wiki/Cold_boot_attack
-[18]: http://www.linux.com/news/featured-blogs/167-amanda-mcpherson/850607-linux-foundation-sysadmins-open-source-their-it-policies
+[18]: https://www.linuxfoundation.org/blog/2015/09/linux-foundation-sysadmins-open-source-their-it-policies/
 [19]: https://firejail.wordpress.com/
 [20]: https://firejail.wordpress.com/documentation-2/firefox-guide/
 [21]: https://www.nitrokey.com/


### PR DESCRIPTION
The hosting space for the initial blog post announcing this work was
moved, and a redirect put in place. That redirect appears to have
stopped, or the article moved again. Either way, this appears to be the
canonical location of the article.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>