### PR TITLE
Note GPG bug when creating NIST auth/sign subkeys

### DIFF
--- a/protecting-code-integrity.md
+++ b/protecting-code-integrity.md
@@ -524,6 +524,10 @@ Then pick NIST (use "nistp256" instead of "cv25519" and "ed25519" below). If
 you just plan to store your subkeys on your computer, then pick ED25519 (the
 GnuPG default).
 
+(Note: If using NIST or Brainpool curves for `sign` or `auth` subkeys, you must
+specify the algorithm explicitly, e.g.: `nistp256/ecdsa` instead of `nistp256`
+due to a long-standing bug [https://dev.gnupg.org/T4052].)
+
 Since you can revoke subkeys and create new ones at any time, this is not a
 life or death kind of decision. If in doubt, pick ed25519.
 


### PR DESCRIPTION
Users who wish to create NIST auth or sign subkeys using the `--quick-add-key` command are likely to trip over a long-standing GPG bug¹ which results in the following error:

    $ gpg --expert --quick-add-key [fpr] nistp256 sign
    gpg: Key generation failed: Wrong key usage
    gpg: Key not changed so no update needed.

Help readers by noting the documented workaround.  The GPG bug has been open since July 2018.  Unfortunately, it seems unlikely to be fixed anytime soon.

¹ https://dev.gnupg.org/T4052

Signed-off-by: Todd Zullinger <tmz@pobox.com>